### PR TITLE
Create macro that automates the addition of new screens

### DIFF
--- a/src/gui/main_menu.rs
+++ b/src/gui/main_menu.rs
@@ -27,11 +27,7 @@ impl ScreenTrait for MainMenu {
                 }),
                 change_screen: true,
             }),
-            Action::Settings => {
-                // TODO: Provide function to initialize settings screen, then change screen to
-                // it
-                Task::done(AppMessage::ChangeScreen(ScreenType::Settings))
-            }
+            Action::Settings => Task::done(AppMessage::ChangeScreen(ScreenType::SettingsScreen)),
             Action::About => Task::done(AppMessage::ChangeScreen(ScreenType::About)),
             Action::Exit => iced::exit(),
         }


### PR DESCRIPTION
Created a macro that reduces the repetitiveness of adding a new variant to three enums, whilst at the same time ensuring uniform naming across variants.